### PR TITLE
Depend on ractor fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2194,8 +2194,7 @@ dependencies = [
 [[package]]
 name = "ractor"
 version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11e9a53fcabb680bb70a3ce495e744676ee7e1800a188e01a68d18916a1b48e1"
+source = "git+https://github.com/planetary-social/ractor.git?branch=output_ports#87af8b584d2293cee1dd8a376b0640e36dc9dd85"
 dependencies = [
  "async-trait",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ log = "0.4.21"
 metrics = "0.23.0"
 metrics-exporter-prometheus = "0.15.0"
 nostr-sdk = "0.31.0"
-ractor = "0.10.3"
+ractor = { git = "https://github.com/planetary-social/ractor.git", branch = "output_ports" }
 regex = "1.10.4"
 reqwest = "0.12.4"
 serde = { version = "1.0.203", features = ["derive"] }


### PR DESCRIPTION
There's a branch that solves the issue described in https://github.com/slawlor/ractor/issues/225 here we depend on a fork own by us to solve this

As a summary, this ensures that if the subscribers are overwhelmed, we see and explicit error and we can either restart or any other preventive measure, but first we need to know that the problem is 
 happening.